### PR TITLE
[iOS] Dismiss on last pop of a nav stack to match android behavior

### DIFF
--- a/lib/ios/native-navigation/ReactNavigation.swift
+++ b/lib/ios/native-navigation/ReactNavigation.swift
@@ -144,7 +144,13 @@ class ReactNavigation: NSObject {
     DispatchQueue.main.async {
       guard let vc = self.coordinator.topViewController() else { return }
       (vc as? ReactViewController)?.dismiss(payload)
-      self.coordinator.topNavigationController()?.popViewController(animated: animated)
+      if let nav = self.coordinator.topNavigationController() {
+        if nav.viewControllers.count == 1 {
+          nav.dismiss(animated: animated, completion: nil)
+        } else {
+          nav.popViewController(animated: animated)
+        }
+      }
     }
   }
 


### PR DESCRIPTION
to: @gpeal 

This puts the ios `Navigator.pop()` behavior to be the same as Androids in that it will dismiss if the viewcontroller is the last of the stack