### PR TITLE
Remove clown town dispatch asyncs

### DIFF
--- a/lib/ios/native-navigation/ReactNavigation.swift
+++ b/lib/ios/native-navigation/ReactNavigation.swift
@@ -53,13 +53,7 @@ class ReactNavigation: NSObject {
   func signalFirstRenderComplete(_ instanceId: String) {
     if let vc = coordinator.viewControllerForId(instanceId) {
       DispatchQueue.main.async {
-        DispatchQueue.main.async {
-          DispatchQueue.main.async {
-            DispatchQueue.main.async {
-              vc.signalFirstRenderComplete()
-            }
-          }
-        }
+        vc.signalFirstRenderComplete()
       }
     }
   }


### PR DESCRIPTION
OK, so this PR probably deserves a bit of an explanation...

A lot of people have been asking about this code, and even [theorizing on the reason for its existence](https://news.ycombinator.com/item?id=13863750).

These dispatches don't actually need to be here. I believe I added them in [while working on tabs](https://github.com/airbnb/native-navigation/commit/fef4c7292e61b8b8ee7a35901562d2fa830e6566) while I was debugging an issue, but these dispatches were not needed to fix it - I just forgot to remove it from the commit 😱

Anyway, just one dispatch should work just fine :)