### PR TITLE
De-register onReactContextInitialized listener after first run

### DIFF
--- a/lib/android/src/main/java/com/airbnb/android/react/navigation/ReactNativeFragment.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/navigation/ReactNativeFragment.java
@@ -129,6 +129,7 @@ public class ReactNativeFragment extends Fragment implements ReactInterface,
               new ReactInstanceManager.ReactInstanceEventListener() {
                 @Override
                 public void onReactContextInitialized(ReactContext context) {
+                  reactInstanceManager.removeReactInstanceEventListener(this);
                   handler.post(new Runnable() {
                     @Override
                     public void run() {


### PR DESCRIPTION
`mReactInstanceManager` listener was being called multiple times after registered (when we pressed `Reload` on react-native development menu, for instance). So `reactRootView.startReactApplication` was being called repeatedly on `onAttachWithReactContext`. 

The app'd throw with `This root view has already been attached to a catalyst instance manager`, as `mReactInstanceManager` was not null anymore after the first run.

De-registering the event listener from `initReactNative` just after it runs seems to fix the issue.