### PR TITLE
add keepCurrent option to Navigator.present()

### DIFF
--- a/docs/api/navigator/present.md
+++ b/docs/api/navigator/present.md
@@ -5,6 +5,7 @@
 1. `screenName` (`string`): The screen identifier of the screen to be pushed.
 2. `props` (`Object`): Props to be passed into the presented screen.
 3. `options` (`Object`): Options for the navigation transition:
+  - `options.keepCurrent` (`boolean`): Whether or not to keep current screen below the new one to be pushed (to use the new like a modal with transparency, for instance)
   - `options.transitionGroup` (`string`): The shared element group ID to use for the shared element
   transition
 

--- a/lib/android/src/main/java/com/airbnb/android/react/navigation/ScreenCoordinator.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/navigation/ScreenCoordinator.java
@@ -141,9 +141,8 @@ public class ScreenCoordinator {
       @Nullable Bundle props,
       @Nullable Bundle options,
       @Nullable Promise promise) {
-    // TODO: use options
     Fragment fragment = ReactNativeFragment.newInstance(moduleName, props);
-    presentScreen(fragment, PresentAnimation.Modal, promise);
+    presentScreen(fragment, options, PresentAnimation.Modal, promise);
   }
 
   public void presentScreen(Fragment fragment) {
@@ -155,6 +154,10 @@ public class ScreenCoordinator {
   }
 
   public void presentScreen(Fragment fragment, PresentAnimation anim, @Nullable Promise promise) {
+    presentScreen(fragment, null, anim, promise);
+  }
+
+  public void presentScreen(Fragment fragment, @Nullable Bundle options, PresentAnimation anim, @Nullable Promise promise) {
     if (fragment == null) {
       throw new IllegalArgumentException("Fragment must not be null.");
     }
@@ -166,7 +169,8 @@ public class ScreenCoordinator {
         .setCustomAnimations(anim.enter, anim.exit, anim.popEnter, anim.popExit);
 
     Fragment currentFragment = getCurrentFragment();
-    if (currentFragment != null) {
+    // TODO: use other options
+    if (currentFragment != null && (options == null || !options.getBoolean("keepCurrent", false))) {
       ft.detach(currentFragment);
     }
     ft

--- a/lib/ios/native-navigation/ReactNavigation.swift
+++ b/lib/ios/native-navigation/ReactNavigation.swift
@@ -110,6 +110,10 @@ class ReactNavigation: NSObject {
       let animated = (options["animated"] as? Bool) ?? true
       let presented = ReactViewController(moduleName: screenName, props: props)
 
+      if ((options["keepCurrent"] as? Bool) ?? false) {
+          presented.modalPresentationStyle = .overCurrentContext
+      }
+
       var makeTransition: (() -> ReactSharedElementTransition)? = nil
 
       if let transitionGroup = options["transitionGroup"] as? String {

--- a/lib/ios/native-navigation/ReactNavigationImplementation.swift
+++ b/lib/ios/native-navigation/ReactNavigationImplementation.swift
@@ -331,7 +331,9 @@ open class DefaultReactNavigationImplementation: ReactNavigationImplementation {
   public func makeNavigationController(rootViewController: UIViewController) -> UINavigationController {
     // TODO(lmr): pass initialConfig
     // TODO(lmr): do we want to provide a way to customize the NavigationBar class?
-    return UINavigationController(rootViewController: rootViewController)
+    let navigationController = UINavigationController(rootViewController: rootViewController)
+    navigationController.modalPresentationStyle = rootViewController.modalPresentationStyle
+    return navigationController
   }
 
   public func reconcileTabConfig(


### PR DESCRIPTION
Add `keepCurrent` option to `Navigator.present()`, to keep current screen below the new one to be pushed (to use the new like a modal with transparency, for instance).