### PR TITLE
Translucent fragments

### DIFF
--- a/docs/api/navigator-config.md
+++ b/docs/api/navigator-config.md
@@ -86,6 +86,7 @@ The
 #### `screenColor: Color`
 
 The background color of the entire screen.
+If the color is translucent, the old screen will be kept below this one (to use it like a modal, for instance).
 
 Defaults to `#FFFFFF`.
 

--- a/lib/android/src/main/java/com/airbnb/android/react/navigation/ScreenCoordinator.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/navigation/ScreenCoordinator.java
@@ -2,6 +2,7 @@ package com.airbnb.android.react.navigation;
 
 import android.annotation.TargetApi;
 import android.app.Activity;
+import android.graphics.Color;
 import android.os.Build;
 import android.os.Bundle;
 import android.support.annotation.AnimRes;
@@ -158,8 +159,8 @@ public class ScreenCoordinator {
       String moduleName = bundle.getString(ReactNativeIntents.EXTRA_MODULE_NAME);
       if (moduleName != null) {
         ReadableMap config = reactNavigationCoordinator.getInitialConfigForModuleName(moduleName);
-        if (config != null && config.hasKey("translucent") && config.getBoolean("translucent")) {
-          return true;
+        if (config != null && config.hasKey("screenColor")) {
+          return Color.alpha(config.getInt("screenColor")) < 255;
         }
       }
     }

--- a/lib/android/src/main/java/com/airbnb/android/react/navigation/ScreenCoordinator.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/navigation/ScreenCoordinator.java
@@ -183,10 +183,9 @@ public class ScreenCoordinator {
         .setCustomAnimations(anim.enter, anim.exit, anim.popEnter, anim.popExit);
 
     Fragment currentFragment = getCurrentFragment();
-    if (currentFragment != null) {
-      if (!isFragmentTranslucent(fragment)) {
-        ft.detach(currentFragment);
-      }
+    if (currentFragment != null && !isFragmentTranslucent(fragment)) {
+      container.willDetachCurrentScreen();
+      ft.detach(currentFragment);
     }
     ft
         .add(container.getId(), fragment)

--- a/lib/android/src/main/java/com/airbnb/android/react/navigation/ScreenCoordinatorLayout.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/navigation/ScreenCoordinatorLayout.java
@@ -97,11 +97,8 @@ public class ScreenCoordinatorLayout extends FrameLayout {
     }
     previousChildrenCount = drawingOps.size();
 
-    if (reverseLastTwoChildren) {
-      while (drawingOps.size() > 2) {
-        drawAndRelease(0);
-      }
-      Collections.reverse(drawingOps);
+    if (reverseLastTwoChildren && drawingOps.size() >= 2) {
+	  Collections.swap(drawingOps, drawingOps.size() - 1, drawingOps.size() - 2);
     }
 
     while (!drawingOps.isEmpty()) {

--- a/lib/android/src/main/java/com/airbnb/android/react/navigation/ScreenCoordinatorLayout.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/navigation/ScreenCoordinatorLayout.java
@@ -46,8 +46,9 @@ public class ScreenCoordinatorLayout extends FrameLayout {
   private List<DrawingOp> drawingOps = new ArrayList<>();
 
   private FragmentManager fragmentManager;
-  boolean reverseLastTwoChildren = false;
-  boolean isDetachingCurrentScreen = false;
+  private boolean reverseLastTwoChildren = false;
+  private boolean isDetachingCurrentScreen = false;
+  private int previousChildrenCount = 0;
 
   public ScreenCoordinatorLayout(@NonNull Context context) {
     super(context);
@@ -74,23 +75,6 @@ public class ScreenCoordinatorLayout extends FrameLayout {
     if (isDetachingCurrentScreen) {
       isDetachingCurrentScreen = false;
       reverseLastTwoChildren = true;
-
-      view.getAnimation().setAnimationListener(new Animation.AnimationListener() {
-        @Override
-        public void onAnimationStart (Animation animation) {
-          // No-op
-        }
-
-        @Override
-        public void onAnimationEnd (Animation animation) {
-          reverseLastTwoChildren = false;
-        }
-
-        @Override
-        public void onAnimationRepeat (Animation animation) {
-          // No-op
-        }
-      });
     }
 
     super.removeView(view);
@@ -99,6 +83,11 @@ public class ScreenCoordinatorLayout extends FrameLayout {
   @Override
   protected void dispatchDraw(Canvas canvas) {
     super.dispatchDraw(canvas);
+
+    if (drawingOps.size() < previousChildrenCount) {
+      reverseLastTwoChildren = false;
+    }
+    previousChildrenCount = drawingOps.size();
 
     while (drawingOps.size() > 2) {
       DrawingOp op = drawingOps.remove(0);

--- a/lib/ios/native-navigation/ReactViewController.swift
+++ b/lib/ios/native-navigation/ReactViewController.swift
@@ -297,7 +297,11 @@ open class ReactViewController: UIViewController {
   }
 
   func prepareViewControllerForPresenting() -> UIViewController {
-    return coordinator.navigation.makeNavigationController(rootViewController: self)
+    let navigationController = coordinator.navigation.makeNavigationController(rootViewController: self)
+    if ((initialConfig["translucent"] as? Bool) ?? false) {
+        navigationController.modalPresentationStyle = .overCurrentContext
+    }
+    return navigationController
   }
 
   fileprivate func reconcileScreenConfig() {

--- a/lib/ios/native-navigation/ReactViewController.swift
+++ b/lib/ios/native-navigation/ReactViewController.swift
@@ -298,8 +298,10 @@ open class ReactViewController: UIViewController {
 
   func prepareViewControllerForPresenting() -> UIViewController {
     let navigationController = coordinator.navigation.makeNavigationController(rootViewController: self)
-    if ((initialConfig["translucent"] as? Bool) ?? false) {
+    if let screenColor = colorForKey("screenColor", initialConfig) {
+      if (screenColor.cgColor.alpha < 1.0) {
         navigationController.modalPresentationStyle = .overCurrentContext
+      }
     }
     return navigationController
   }


### PR DESCRIPTION
Keep old screen below the new one to be presented if the new screen's `screenColor` is translucent (to use like modals, for instance).

Supersedes https://github.com/airbnb/native-navigation/pull/60