### PR TITLE
[Android] Updated the ColorStateList for Tab Bars containing less then 4 tabs

### DIFF
--- a/lib/android/src/main/java/com/airbnb/android/react/navigation/DefaultNavigationImplementation.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/navigation/DefaultNavigationImplementation.java
@@ -614,8 +614,8 @@ public class DefaultNavigationImplementation implements NavigationImplementation
     return new ColorStateList(
         new int[][]{
             new int[]{android.R.attr.state_pressed},
+            new int[]{android.R.attr.state_checked},
             new int[]{android.R.attr.state_enabled},
-            new int[]{android.R.attr.state_focused, android.R.attr.state_pressed},
             new int[]{-android.R.attr.state_enabled},
             new int[]{} // this should be empty to make default color as we want
         },


### PR DESCRIPTION
Props `itemTextColor`, `itemTextActiveColor`, `itemTextSelectedColor` and `itemTextDisabledColor`don't behave properly when there is 3 or less tabs.

Example:
```js
import React from 'react';
import { TabBar, Tab } from 'native-navigation';

const propTypes = {};
const defaultProps = {};

export default class TabScreen extends React.Component {
  render() {
    return (
      <TabBar
        elevation={20}
        itemTextColor="black"
        itemTextActiveColor="green"
        itemTextSelectedColor="red"
        itemTextDisabledColor="blue"
      >
        <Tab
          route={'ScreenOne'}
          title="Home"
          image={require('../icons/home.png')}
        />
        <Tab
          route={'ScreenOne'}
          title="Chat"
          image={require('../icons/chat.png')}
        />
        <Tab
          route={'ScreenOne'}
          enabled={false}
          title="Data"
          image={require('../icons/backup.png')}
        />
      </TabBar>
    );
  }
}

TabScreen.defaultProps = defaultProps;
TabScreen.propTypes = propTypes;
```

This PR doesn't change the behaviour of Tab Bars containing 4 tabs or more.

Note that this change does affect icons but due to another issue in the example project the icons remain black before and after this change is applied regardless of the values assigned to `itemIcon*`.