### PR TITLE
Fix content inset issues

### DIFF
--- a/example/components/Screen.js
+++ b/example/components/Screen.js
@@ -38,7 +38,6 @@ export default class Screen extends React.Component {
         onDisappear={() => console.log('onDisappear', this.context.nativeNavigationInstanceId)}
       >
         <ScrollView>
-          <Navigator.Spacer animated />
           {children}
         </ScrollView>
       </Navigator.Config>

--- a/example/ios/native-navigation.xcodeproj/project.pbxproj
+++ b/example/ios/native-navigation.xcodeproj/project.pbxproj
@@ -328,6 +328,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				INFOPLIST_FILE = "native-navigation/Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				MODULE_NAME = ExampleApp;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.airbnb.native-navigation.example";
@@ -342,6 +343,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				INFOPLIST_FILE = "native-navigation/Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				MODULE_NAME = ExampleApp;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.airbnb.native-navigation.example";

--- a/example/ios/native-navigation/ViewController.swift
+++ b/example/ios/native-navigation/ViewController.swift
@@ -13,37 +13,24 @@ final class ViewController: UIViewController {
 
   override func viewDidLoad() {
     super.viewDidLoad()
-    title = "Root"
+    title = "Example"
 
     let pushButton1 = UIButton(type: .roundedRect)
     pushButton1.setTitle("Push ScreenOne", for: .normal)
     pushButton1.addTarget(self, action: #selector(pushScreenOne(sender:)), for: .touchUpInside)
-    pushButton1.frame = CGRect(x: 0, y: 100, width: 320, height: 60)
+    pushButton1.translatesAutoresizingMaskIntoConstraints = false
     view.addSubview(pushButton1)
+    pushButton1.centerXAnchor.constraint(equalTo: view.centerXAnchor).isActive = true
+    pushButton1.topAnchor.constraint(equalTo: self.topLayoutGuide.bottomAnchor, constant: 100).isActive = true
+    
 
     let pushButton2 = UIButton(type: .roundedRect)
     pushButton2.setTitle("Push TabScreen", for: .normal)
     pushButton2.addTarget(self, action: #selector(pushTabScreen(sender:)), for: .touchUpInside)
-    pushButton2.frame = CGRect(x: 0, y: 160, width: 320, height: 60)
+    pushButton2.translatesAutoresizingMaskIntoConstraints = false
     view.addSubview(pushButton2)
-
-//    let button = UIButton(type: .roundedRect)
-//    button.setTitle("Push ScreenOne", for: .normal)
-//    button.addTarget(self, action: "pushScreenOne", for: .touchUpInside)
-//    view.addSubview(button)
-
-//    UIButton *button = [UIButton buttonWithType:UIButtonTypeRoundedRect];
-//    [button setTitle:@"Push ScreenOne" forState:UIControlStateNormal];
-//    button.frame = CGRectMake(0, 100, 320, 140);
-//    [button addTarget:self action:@selector(pushScreenOne) forControlEvents:UIControlEventTouchUpInside];
-//    [self.view addSubview:button];
-//
-//    UIButton *button2 = [UIButton buttonWithType:UIButtonTypeRoundedRect];
-//    [button2 setTitle:@"Push TabBar" forState:UIControlStateNormal];
-//    button2.frame = CGRectMake(0, 300, 320, 140);
-//    [button2 addTarget:self action:@selector(pushTabBar) forControlEvents:UIControlEventTouchUpInside];
-//    [self.view addSubview:button2];
-
+    pushButton2.centerXAnchor.constraint(equalTo: view.centerXAnchor).isActive = true
+    pushButton2.topAnchor.constraint(equalTo: pushButton1.bottomAnchor, constant: 40).isActive = true
 
     view.backgroundColor = .white
   }

--- a/lib/ios/native-navigation/ReactViewController.swift
+++ b/lib/ios/native-navigation/ReactViewController.swift
@@ -213,8 +213,25 @@ open class ReactViewController: UIViewController {
       }
     }
   }
-
-
+  
+  override open func viewDidLayoutSubviews() {
+    super.viewDidLayoutSubviews()
+    let _ = findScrollViewAndRefreshContentInset(in: view)
+  }
+  
+  // Do something similar to RCTFindScrollViewAndRefreshContentInsetInView in RCTWrapperViewController
+  private func findScrollViewAndRefreshContentInset(in view: UIView) -> Bool {
+    if let coolView = view as? RCTAutoInsetsProtocol {
+      coolView.refreshContentInset()
+      return true
+    }
+    for subview in view.subviews {
+      if findScrollViewAndRefreshContentInset(in: subview) {
+        return true
+      }
+    }
+    return false
+  }
 
 
   // MARK: Public Setters


### PR DESCRIPTION
This fixes content inset issues due to translucent navigation bars and tab bars. Prior, a `Spacer` was needed that calculated the correct size. This only worked for the navigation bar though, and not the tab bar on bottom.

This does something similar to a class in React Native (`RCTWrapperViewController`), and tries to calculate it automatically for any view (such as an `RCTScrollView`) that conforms to `RCTAutoInsetsProtocol`.

`Spacer` in theory should no longer be needed, but I have left it in for now in case anyone else should need it.