### PR TITLE
Cleanup warnings, implement some tab/tabbar props

### DIFF
--- a/docs/api/navigator-tab-bar.md
+++ b/docs/api/navigator-tab-bar.md
@@ -16,6 +16,10 @@ The following props are defined on the tab bar as a part of the [DefaultImplemen
 
 #### `backgroundImage: Image`
 
+#### `shadowImage: Image`
+
+#### `selectionIndicatorImage: Image`
+
 #### `elevation: number`
 
 #### `translucent: boolean`

--- a/docs/api/navigator-tab.md
+++ b/docs/api/navigator-tab.md
@@ -21,6 +21,8 @@ The following props are defined on tab as a part of the [DefaultImplementation](
 
 #### `image: Image`
 
+#### `selectedImage: Image`
+
 #### `title: string`
 
 #### `titleFontSize: number`
@@ -30,6 +32,8 @@ The following props are defined on tab as a part of the [DefaultImplementation](
 #### `titleFontName: string`
 
 #### `badgeValue: number`
+
+#### `badgeColor: Color`
 
 #### `badgeFontSize: number`
 

--- a/lib/ios/native-navigation/Dictionary+FunctionalExtensions.swift
+++ b/lib/ios/native-navigation/Dictionary+FunctionalExtensions.swift
@@ -25,8 +25,8 @@ extension Dictionary {
 
   public func combineWith(values: [Key: Value]) -> [Key: Value] {
     var out = [Key: Value]()
-    out.merge(values: self);
-    out.merge(values: values);
+    let _ = out.merge(values: self);
+    let _ = out.merge(values: values);
     return out;
   }
 


### PR DESCRIPTION
This cleans up a number of warnings in the project, mostly unused variables and such, and cleans up comments that are no longer needed because what is commented has already been implemented.

It also adds a number of additional support in iOS for a number of different `UITabBar` and `UITabBarItem` props.