### PR TITLE
Add support for various modal presentation styles

### DIFF
--- a/docs/api/navigator/present.md
+++ b/docs/api/navigator/present.md
@@ -5,8 +5,11 @@
 1. `screenName` (`string`): The screen identifier of the screen to be pushed.
 2. `props` (`Object`): Props to be passed into the presented screen.
 3. `options` (`Object`): Options for the navigation transition:
-  - `options.transitionGroup` (`string`): The shared element group ID to use for the shared element
+  - `options.transitionGroup` (`string`): The shared element group ID to use for the shared element 
   transition
+  - `options.modalPresentationStyle` (`string`, iOS only): The presentation style to use when presenting
+  the view modally. Either `fullScreen` (default), `pageSheet`, `formSheet`, `currentContext`, `custom`,
+  `overFullScreen`, `overCurrentContext`, `popover` or `none`.
 
 ## Returns
 

--- a/lib/ios/native-navigation/ReactNavigation.swift
+++ b/lib/ios/native-navigation/ReactNavigation.swift
@@ -135,26 +135,16 @@ class ReactNavigation: NSObject {
     }
     
     switch modalPresentationStyle {
-    case "fullScreen":
-      return .fullScreen
-    case "pageSheet":
-      return .pageSheet
-    case "formSheet":
-      return .formSheet
-    case "currentContext":
-      return .currentContext
-    case "custom":
-      return .custom
-    case "overFullScreen":
-      return .overFullScreen
-    case "overCurrentContext":
-      return .overCurrentContext
-    case "popover":
-      return .popover
-    case "none":
-      return .none
-    default:
-      return .fullScreen // This is the system default
+    case "fullScreen":          return .fullScreen
+    case "pageSheet":           return .pageSheet
+    case "formSheet":           return .formSheet
+    case "currentContext":      return .currentContext
+    case "custom":              return .custom
+    case "overFullScreen":      return .overFullScreen
+    case "overCurrentContext":  return .overCurrentContext
+    case "popover":             return .popover
+    case "none":                return .none
+    default:                    return .fullScreen // This is the system default
     }
   }
   

--- a/lib/ios/native-navigation/ReactNavigation.swift
+++ b/lib/ios/native-navigation/ReactNavigation.swift
@@ -125,7 +125,36 @@ class ReactNavigation: NSObject {
       }
 
       self.coordinator.registerFlow(presented, resolve: resolve, reject: reject)
-      nav.presentReactViewController(presented, animated: animated, completion: nil, makeTransition: makeTransition)
+      nav.presentReactViewController(presented, animated: animated, completion: nil, presentationStyle: self.modalPresentationStyle(from: options), makeTransition: makeTransition)
+    }
+  }
+  
+  private func modalPresentationStyle(from options: [String: Any]) -> UIModalPresentationStyle {
+    guard let modalPresentationStyle = options["modalPresentationStyle"] as? String else {
+      return .fullScreen // this is the system default
+    }
+    
+    switch modalPresentationStyle {
+    case "fullScreen":
+      return .fullScreen
+    case "pageSheet":
+      return .pageSheet
+    case "formSheet":
+      return .formSheet
+    case "currentContext":
+      return .currentContext
+    case "custom":
+      return .custom
+    case "overFullScreen":
+      return .overFullScreen
+    case "overCurrentContext":
+      return .overCurrentContext
+    case "popover":
+      return .popover
+    case "none":
+      return .none
+    default:
+      return .fullScreen // This is the system default
     }
   }
   

--- a/lib/ios/native-navigation/ReactViewControllerProtocol.swift
+++ b/lib/ios/native-navigation/ReactViewControllerProtocol.swift
@@ -61,12 +61,13 @@ extension UIViewController {
     animated: Bool,
     completion: (() -> Void)?
   ) {
-    presentReactViewController(viewControllerToPresent, animated: animated, completion: completion, makeTransition: nil)
+    presentReactViewController(viewControllerToPresent, animated: animated, completion: completion, presentationStyle: .fullScreen, makeTransition: nil)
   }
   public func presentReactViewController(
     _ viewControllerToPresent: ReactViewControllerProtocol,
     animated: Bool,
     completion: (() -> Void)?,
+    presentationStyle: UIModalPresentationStyle = .fullScreen,
     makeTransition: (() -> ReactSharedElementTransition)?
   ) {
     guard let irvc = viewControllerToPresent as? InternalReactViewControllerProtocol else {
@@ -76,13 +77,14 @@ extension UIViewController {
       }
       return
     }
-    internalPresentReactViewController(irvc, animated: animated, completion: completion, makeTransition: makeTransition)
+    internalPresentReactViewController(irvc, animated: animated, completion: completion, presentationStyle: presentationStyle, makeTransition: makeTransition)
   }
 
   func internalPresentReactViewController(
     _ rvc: InternalReactViewControllerProtocol,
     animated: Bool,
     completion: (() -> Void)?,
+    presentationStyle: UIModalPresentationStyle,
     makeTransition: (() -> ReactSharedElementTransition)?
   ) {
 
@@ -124,6 +126,9 @@ extension UIViewController {
         rvc.transition = transition
         viewControllerToPresent.transitioningDelegate = transition
       }
+      
+      viewControllerToPresent.modalPresentationStyle = presentationStyle
+      // TODO: preferredContentSize - for popover types
 
       self?.present(viewControllerToPresent, animated: animated, completion: {
         rvc.isCurrentlyTransitioning = false


### PR DESCRIPTION
This adds support for configuring the modal presentation style on a view presented modally in iOS. Full screen is the system default, which is cool, but not helpful when you want to show something as a form sheet in horizontally regular environments (iPhone plus sized in landscape, iPad), or as a popover.

This allows `modalPresentationStyle` to be passed as an option when presenting modally.