### PR TITLE
Use correct event prefix

### DIFF
--- a/lib/android/src/main/java/com/airbnb/android/react/navigation/ReactNativeFragment.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/navigation/ReactNativeFragment.java
@@ -47,7 +47,6 @@ public class ReactNativeFragment extends Fragment implements ReactInterface,
   private static final String ON_APPEAR = "onAppear";
   private static final String INSTANCE_ID_PROP = "nativeNavigationInstanceId";
   private static final String ON_BUTTON_PRESS = "onButtonPress";
-  private static final String ON_LINK_PRESS = "onLinkPress";
   private static final String INITIAL_BAR_HEIGHT_PROP = "nativeNavigationInitialBarHeight";
   private static final int RENDER_TIMEOUT_IN_MS = 1700; // TODO(lmr): put this back down when done debugging
 
@@ -419,13 +418,6 @@ public class ReactNativeFragment extends Fragment implements ReactInterface,
     super.onPrepareOptionsMenu(menu);
   }
 
-  @Override
-  public boolean onOptionsItemSelected(MenuItem item) {
-    // it's the link
-    emitEvent(ON_LINK_PRESS, null);
-    return false;
-  }
-
   private boolean isSuccessfullyInitialized() {
     return reactNavigationCoordinator.isSuccessfullyInitialized();
   }
@@ -437,7 +429,7 @@ public class ReactNativeFragment extends Fragment implements ReactInterface,
   public void emitEvent(String eventName, Object object) {
     if (isSuccessfullyInitialized()) {
       String key =
-              String.format(Locale.ENGLISH, "AirbnbNavigatorScreen.%s.%s", eventName, instanceId);
+              String.format(Locale.ENGLISH, "NativeNavigationScreen.%s.%s", eventName, instanceId);
       maybeEmitEvent(reactInstanceManager.getCurrentReactContext(), key, object);
     }
   }

--- a/lib/android/src/main/java/com/airbnb/android/react/navigation/ReactToolbar.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/navigation/ReactToolbar.java
@@ -10,6 +10,7 @@ import android.util.Log;
 import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
+import com.facebook.react.bridge.ReadableType;
 import com.facebook.react.views.toolbar.DrawableWithIntrinsicSize;
 
 import com.facebook.drawee.backends.pipeline.Fresco;
@@ -237,12 +238,15 @@ public class ReactToolbar extends Toolbar {
   }
 
   /* package */ void setRightButtons(Menu menu, ReadableArray buttons, final ReactInterface component) {
-    Log.d(TAG, "");
     mActionsHolder.clear();
     for (int i = 0; i < buttons.size(); i++) {
       ReadableMap button = buttons.getMap(i);
 
-      MenuItem item = menu.add(Menu.NONE, Menu.NONE, i, button.getString("title"));
+      String title = button.hasKey("title") && button.getType("title") == ReadableType.String
+          ? button.getString("title")
+          : String.format("Item %s", i);
+
+      MenuItem item = menu.add(Menu.NONE, Menu.NONE, i, title);
 
       if (button.hasKey("image")) {
         setMenuItemIcon(item, button.getMap("image"));


### PR DESCRIPTION
to: @gpeal 

Android events weren't firing because we were using the wrong event prefix.

Also, buttons on android were assuming a title would always be provided, which isn't always the case, causing a crash.