### PR TITLE
Set an id to container view in ReactActivity

### DIFF
--- a/lib/android/src/main/java/com/airbnb/android/react/navigation/ReactActivity.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/navigation/ReactActivity.java
@@ -4,6 +4,7 @@ import android.os.Bundle;
 import android.support.annotation.Nullable;
 import android.view.Gravity;
 import android.view.ViewGroup;
+import com.airbnb.android.R;
 
 public abstract class ReactActivity extends ReactAwareActivity implements ScreenCoordinatorComponent {
   private static final String TAG = ReactActivity.class.getSimpleName();
@@ -21,6 +22,7 @@ public abstract class ReactActivity extends ReactAwareActivity implements Screen
         )
     );
     container.setForegroundGravity(Gravity.CENTER);
+    container.setId(R.id.react_activity_container_id);
     setContentView(container);
 
     screenCoordinator = new ScreenCoordinator(this, container, savedInstanceState);

--- a/lib/android/src/main/res/values/ids.xml
+++ b/lib/android/src/main/res/values/ids.xml
@@ -3,4 +3,5 @@
     <item name="react_shared_element_transition_name" type="id" />
     <item name="react_shared_element_screen_instance_id" type="id" />
     <item name="react_shared_element_group_id" type="id" />
+    <item name="react_activity_container_id" type="id" />
 </resources>


### PR DESCRIPTION
to: @gpeal 

This was a crasher in the new release if people used `ReactActivity` (which our example app is not). Tested and this fixes the issue.