### PR TITLE
Implement additional nav bar props

### DIFF
--- a/docs/api/navigator-config.md
+++ b/docs/api/navigator-config.md
@@ -119,6 +119,13 @@ Defaults to `'fade'`.
 #### `statusBarStyle: 'light' | 'default'`
 
 
+#### `barStyle: 'black' | 'default' (iOS)`
+
+Configures the bar style effectively updating the status bar color for views inside a navigator.
+
+#### `shadowImage: Image (iOS)`
+
+Image for the shadow drawn under the nav bar.
 
 
 

--- a/docs/api/navigator-config.md
+++ b/docs/api/navigator-config.md
@@ -232,6 +232,8 @@ type NavigatorConfigProps = {
   isToolbarHidden: boolean;
   backIndicatorTransitionMaskImage: Image;
   translucent: boolean;
+  barStyle: string;
+  shadowImage: Image;
   
   // android-only
   statusBarColor: Color;

--- a/docs/api/navigator-config.md
+++ b/docs/api/navigator-config.md
@@ -127,6 +127,10 @@ Configures the bar style effectively updating the status bar color for views ins
 
 Image for the shadow drawn under the nav bar.
 
+#### `image: Image`
+
+Image shown in the center of the nav bar. If set, this replaces the title that would have been shown.
+
 
 
 ## Events
@@ -216,6 +220,7 @@ type NavigatorConfigProps = {
   titleFontSize: number;
   subtitleFontName: string;
   subtitleFontSize: number;
+  image: Image;
   
   // android-only-but-should-share
   navIcon: Image;

--- a/lib/ios/native-navigation/ReactNavigationImplementation.swift
+++ b/lib/ios/native-navigation/ReactNavigationImplementation.swift
@@ -556,9 +556,16 @@ open class DefaultReactNavigationImplementation: ReactNavigationImplementation {
       if let translucent = boolForKey("translucent", next) {
         navBar.isTranslucent = translucent
       }
-
-      //    navigationController?.navigationBar.barStyle = .blackTranslucent
-      //    navigationController?.navigationBar.shadowImage = nil
+        
+      if let barStyle = stringForKey("barStyle", next) {
+        navBar.barStyle = barStyle == "black" ? .black : .default
+      }
+        
+      if let shadowImage = imageForKey("shadowImage", next) {
+        navBar.shadowImage = shadowImage
+      } else {
+        navBar.shadowImage = nil
+      }
     }
 
 //    viewController.navigationItem.titleView = nil

--- a/lib/ios/native-navigation/ReactNavigationImplementation.swift
+++ b/lib/ios/native-navigation/ReactNavigationImplementation.swift
@@ -504,6 +504,10 @@ open class DefaultReactNavigationImplementation: ReactNavigationImplementation {
     if let hidesBackButton = boolForKey("hidesBackButton", next) {
       navItem.setHidesBackButton(hidesBackButton, animated: true)
     }
+    
+    if let image = imageForKey("image", next) {
+      navItem.titleView = UIImageView(image: image)
+    }
 
     if let navController = navigationController {
 


### PR DESCRIPTION
In iOS, when a `UIViewController` is embedded inside a `UINavigationController`, setting the `preferredStatusBarStyle` (as done through the `statusBarStyle` prop in this library), has no effect, and `UINavigationController` returns either a light or dark status bar based on the bar style of its navigation bar. This will make things “work” in this case by allowing the developer to set if the barstyle is dark or not.

I also added `image` - to be shown in the `titleView`. I noticed in Android there is a `logo` and `navIcon` in the "should share" list, are either one of those similar?