### PR TITLE
Prevent destroying ReactNativeActivity or ReactNativeTabActivity

### DIFF
--- a/lib/android/src/main/AndroidManifest.xml
+++ b/lib/android/src/main/AndroidManifest.xml
@@ -9,9 +9,11 @@
   <application>
     <activity
       android:name="com.airbnb.android.react.navigation.ReactNativeActivity"
-      android:launchMode="singleTop"/>
+      android:launchMode="singleTop"
+      android:configChanges="keyboard|keyboardHidden|orientation|screenSize" />
     <activity
       android:name="com.airbnb.android.react.navigation.ReactNativeTabActivity"
-      android:launchMode="singleTop"/>
+      android:launchMode="singleTop"
+      android:configChanges="keyboard|keyboardHidden|orientation|screenSize" />
   </application>
 </manifest>


### PR DESCRIPTION
Prevent destroying ReactNativeActivity or ReactNativeTabActivity on runtime changes (http://developer.android.com/guide/topics/resources/runtime-changes.html)

I noticed that the example included in this repo crashes on screen rotation because Android destroys and re-creates the `ReactNativeTabActivity`. Android remembers the `TabView`s which were created before the rotation and adds them back itself - resulting in duplicate `TabView`s, forcing the app to crash because the maximum allowed items for a menu (`java.lang.IllegalArgumentException: Maximum number of items supported by BottomNavigationView is 5.`) is exceeded.

I am not sure if you really want to merge these changes in and if there are dangerous implications. At least this is considered "default" by react-native: https://github.com/facebook/react-native/blob/master/local-cli/templates/HelloWorld/android/app/src/main/AndroidManifest.xml#L22