### PR TITLE
Add convenience init with a single moduleName argument to ReactTabBarController

### DIFF
--- a/lib/ios/native-navigation/ReactTabBarController.swift
+++ b/lib/ios/native-navigation/ReactTabBarController.swift
@@ -40,6 +40,10 @@ open class ReactTabBarController: UITabBarController {
   fileprivate var tabViews: [TabView] = []
   private var barHeight: CGFloat
 
+  public convenience init(moduleName: String) {
+    self.init(moduleName: moduleName, props: [:])
+  }
+
   public init(moduleName: String, props: [String: AnyObject] = [:]) {
     self.nativeNavigationInstanceId = generateId(moduleName)
     self.moduleName = moduleName


### PR DESCRIPTION
- mimics identical method on ReactViewController
- makes usage from Objective-C easier, making this possible
  - `[[ReactTabBarController alloc] initWithModuleName:@"NAME"]`