### PR TITLE
[example] Add titles for Tab screens, Add default title for ExampleScreen

### DIFF
--- a/example/screens/NavigationExampleScreen.js
+++ b/example/screens/NavigationExampleScreen.js
@@ -13,7 +13,9 @@ import Screen from '../components/Screen';
 import Row from '../components/Row';
 
 const propTypes = {};
-const defaultProps = {};
+const defaultProps = {
+  title: 'A Screen'
+};
 const contextTypes = {
   nativeNavigationInstanceId: PropTypes.string,
 };
@@ -23,7 +25,7 @@ const { width } = Dimensions.get('window');
 export default class NavigationExampleScreen extends Component {
   render() {
     return (
-      <Screen>
+      <Screen title={this.props.title}>
         <LoremImage
           width={width}
           height={width / 1.6}

--- a/example/screens/TabScreen.js
+++ b/example/screens/TabScreen.js
@@ -13,21 +13,25 @@ export default class TabScreen extends React.Component {
         <Tab
           route={'ScreenOne'}
           title="Home"
+          props={{ title: 'Home' }}
           image={require('../icons/home.png')}
         />
         <Tab
           route={'ScreenOne'}
           title="Chat"
+          props={{ title: 'Chat' }}
           image={require('../icons/chat.png')}
         />
         <Tab
           route={'ScreenOne'}
           title="Data"
+          props={{ title: 'Data' }}
           image={require('../icons/backup.png')}
         />
         <Tab
           route={'ScreenOne'}
           title="Settings"
+          props={{ title: 'Settings' }}
           image={require('../icons/settings.png')}
         />
       </TabBar>


### PR DESCRIPTION
In general it's a good idea to have the example 1. look kind of like a real app, 2. exercise more of the API. This change improves on both counts. Also, found a bug when testing this, see #110