### PR TITLE
[minor] Fix podspec summary (wrong project)

### DIFF
--- a/native-navigation.podspec
+++ b/native-navigation.podspec
@@ -5,7 +5,7 @@ package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 Pod::Spec.new do |s|
   s.name         = "native-navigation"
   s.version      = package['version']
-  s.summary      = "React Native Mapview component for iOS + Android"
+  s.summary      = "Native navigation library for React Native applications"
 
   s.authors      = { "intelligibabble" => "leland.m.richardson@gmail.com" }
   s.homepage     = "https://github.com/airbnb/native-navigation#readme"


### PR DESCRIPTION
Just a very minor tweak. It appears that the podspec's summary is describing https://github.com/airbnb/react-native-maps, so probably just a copy-and-paste error.

Thanks for putting together such a neat project!