### PR TITLE
Update ViewStub margin if doesn't have ActionBar

### DIFF
--- a/lib/android/src/main/java/com/airbnb/android/react/navigation/DefaultNavigationImplementation.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/navigation/DefaultNavigationImplementation.java
@@ -381,6 +381,11 @@ public class DefaultNavigationImplementation implements NavigationImplementation
 
         if (hidden && bar.isShowing()) {
           bar.hide();
+
+          // set viewStub margin for 0 if hide
+          ViewStub viewStub = component.getViewStub();
+          ViewGroup.MarginLayoutParams marginLayoutParams = (ViewGroup.MarginLayoutParams) viewStub.getLayoutParams();
+          marginLayoutParams.setMargins(0, 0, 0, 0);
         } else if (!hidden && !bar.isShowing()) {
           bar.show();
         }

--- a/lib/android/src/main/java/com/airbnb/android/react/navigation/ReactInterface.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/navigation/ReactInterface.java
@@ -1,6 +1,7 @@
 package com.airbnb.android.react.navigation;
 
 import android.support.v4.app.FragmentActivity;
+import android.view.ViewStub;
 
 import com.facebook.react.ReactRootView;
 import com.facebook.react.bridge.ReadableMap;
@@ -12,6 +13,7 @@ public interface ReactInterface {
   String getInstanceId();
   ReactRootView getReactRootView();
   ReactToolbar getToolbar();
+  ViewStub getViewStub();
   boolean isDismissible();
   void signalFirstRenderComplete();
   void notifySharedElementAddition();

--- a/lib/android/src/main/java/com/airbnb/android/react/navigation/ReactNativeFragment.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/navigation/ReactNativeFragment.java
@@ -72,6 +72,7 @@ public class ReactNativeFragment extends Fragment implements ReactInterface,
   private ReadableMap renderedConfig = ConversionUtil.EMPTY_MAP;
   private ReactNativeFragmentViewGroup contentContainer;
   private ReactRootView reactRootView;
+  private ViewStub viewStub = null;
   //  private ReactInterfaceManager activityManager;
   private final Handler handler = new Handler();
   private PermissionListener permissionListener;
@@ -173,9 +174,12 @@ public class ReactNativeFragment extends Fragment implements ReactInterface,
     }
     props.putString(INSTANCE_ID_PROP, instanceId);
 
+    if (viewStub == null || reactRootView == null) {
+      viewStub = (ViewStub) getView().findViewById(R.id.react_root_view_stub);
+    }
+
     if (reactRootView == null) {
-      ViewStub reactViewStub = (ViewStub) getView().findViewById(R.id.react_root_view_stub);
-      reactRootView = (ReactRootView) reactViewStub.inflate();
+      reactRootView = (ReactRootView) viewStub.inflate();
     }
 
     getImplementation().reconcileNavigationProperties(
@@ -372,6 +376,11 @@ public class ReactNativeFragment extends Fragment implements ReactInterface,
   @Override
   public ReactToolbar getToolbar() {
     return toolbar;
+  }
+
+  @Override
+  public ViewStub getViewStub() {
+    return viewStub;
   }
 
   @Override


### PR DESCRIPTION
In the actual setup, if you hide the `ActionBar`, the `ViewStub` keeps the margin top, that generates a blank space above the content.

This PR implements a margin reset in case `ActionBar` is hidden. 

This probably fix #59 and #104.