### PR TITLE
[Android] Delete redundant gen directory.

### DIFF
--- a/example/android/app/src/main/gen/com/example/BuildConfig.java
+++ b/example/android/app/src/main/gen/com/example/BuildConfig.java
@@ -1,8 +1,0 @@
-/*___Generated_by_IDEA___*/
-
-package com.example;
-
-/* This stub is only used by the IDE. It is NOT the BuildConfig class actually packed into the APK */
-public final class BuildConfig {
-  public final static boolean DEBUG = Boolean.parseBoolean(null);
-}

--- a/example/android/app/src/main/gen/com/example/Manifest.java
+++ b/example/android/app/src/main/gen/com/example/Manifest.java
@@ -1,7 +1,0 @@
-/*___Generated_by_IDEA___*/
-
-package com.example;
-
-/* This stub is only used by the IDE. It is NOT the Manifest class actually packed into the APK */
-public final class Manifest {
-}

--- a/example/android/app/src/main/gen/com/example/R.java
+++ b/example/android/app/src/main/gen/com/example/R.java
@@ -1,7 +1,0 @@
-/*___Generated_by_IDEA___*/
-
-package com.example;
-
-/* This stub is only used by the IDE. It is NOT the R class actually packed into the APK */
-public final class R {
-}

--- a/lib/android/src/main/gen/com/airbnb/android/BuildConfig.java
+++ b/lib/android/src/main/gen/com/airbnb/android/BuildConfig.java
@@ -1,8 +1,0 @@
-/*___Generated_by_IDEA___*/
-
-package com.airbnb.android;
-
-/* This stub is only used by the IDE. It is NOT the BuildConfig class actually packed into the APK */
-public final class BuildConfig {
-  public final static boolean DEBUG = Boolean.parseBoolean(null);
-}

--- a/lib/android/src/main/gen/com/airbnb/android/Manifest.java
+++ b/lib/android/src/main/gen/com/airbnb/android/Manifest.java
@@ -1,7 +1,0 @@
-/*___Generated_by_IDEA___*/
-
-package com.airbnb.android;
-
-/* This stub is only used by the IDE. It is NOT the Manifest class actually packed into the APK */
-public final class Manifest {
-}

--- a/lib/android/src/main/gen/com/airbnb/android/R.java
+++ b/lib/android/src/main/gen/com/airbnb/android/R.java
@@ -1,7 +1,0 @@
-/*___Generated_by_IDEA___*/
-
-package com.airbnb.android;
-
-/* This stub is only used by the IDE. It is NOT the R class actually packed into the APK */
-public final class R {
-}


### PR DESCRIPTION
The folder and the files are left overs from an older build system and are not needed.