### PR TITLE
[android] Use module name from intent for tab screens

### DIFF
--- a/lib/android/src/main/java/com/airbnb/android/react/navigation/ReactNativeTabActivity.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/navigation/ReactNativeTabActivity.java
@@ -65,7 +65,10 @@ public class ReactNativeTabActivity extends ReactAwareActivity
     ScreenCoordinatorLayout container = (ScreenCoordinatorLayout) findViewById(R.id.content);
     tabCoordinator = new TabCoordinator(this, container, savedInstanceState);
 
-    ReactNativeFragment tabConfigFragment = ReactNativeFragment.newInstance("TabScreen", null);
+    ReactNativeFragment tabConfigFragment = ReactNativeFragment.newInstance(
+            getIntent().getStringExtra(ReactNativeIntents.EXTRA_MODULE_NAME),
+            null
+    );
     getSupportFragmentManager().beginTransaction()
             .add(R.id.tab_config_container, tabConfigFragment)
             .commitNow();


### PR DESCRIPTION
It was hardcoded to use `"TabScreen"` before, but my prototype is using the fancy name `"MainAppAndWhateverTabBar"`.

(I'll work on my naming in the meantime)

((Thank you for the library! So far it's working fairly well for us!)