### PR TITLE
RN 0.50 and Xcode 9 compatible

### DIFF
--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -1,12 +1,24 @@
+react_native_path = '../../node_modules/react-native'
+
 use_frameworks!
 
 project 'native-navigation.xcodeproj'
 
 target 'native-navigation' do
-  pod 'Yoga', :path => '../../node_modules/react-native/ReactCommon/yoga/Yoga.podspec'
   pod 'native-navigation', :path => '../../'
-  pod 'React', :path => '../../node_modules/react-native', :subspecs => [
+
+  # To use CocoaPods with React Native, you need to add this specific Yoga spec as well
+  pod 'yoga', :path => react_native_path + '/ReactCommon/yoga/yoga.podspec'
+
+  # Third party deps used for CxxBridge
+  pod 'DoubleConversion', :podspec => react_native_path + '/third-party-podspecs/DoubleConversion.podspec'
+  pod 'GLog', :podspec => react_native_path + '/third-party-podspecs/GLog.podspec'
+  pod 'Folly', :podspec => react_native_path + '/third-party-podspecs/Folly.podspec'
+
+  pod 'React', :path => react_native_path, :subspecs => [
     'Core',
+    'DevSupport',
+    'CxxBridge',
     'RCTText',
     'RCTNetwork',
     'RCTWebSocket', # needed for debugging

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,50 +1,102 @@
 PODS:
-  - native-navigation (0.1.0):
+  - boost (1.59.0):
+    - boost/graph-includes (= 1.59.0)
+    - boost/math-includes (= 1.59.0)
+    - boost/numeric-includes (= 1.59.0)
+    - boost/pointer_cast-includes (= 1.59.0)
+    - boost/preprocessor-includes (= 1.59.0)
+    - boost/shared_ptr-includes (= 1.59.0)
+    - boost/string_algorithms-includes (= 1.59.0)
+  - boost/graph-includes (1.59.0)
+  - boost/math-includes (1.59.0)
+  - boost/numeric-includes (1.59.0)
+  - boost/pointer_cast-includes (1.59.0)
+  - boost/preprocessor-includes (1.59.0)
+  - boost/shared_ptr-includes (1.59.0)
+  - boost/string_algorithms-includes (1.59.0)
+  - DoubleConversion (1.1.5)
+  - Folly (2016.09.26.00):
+    - boost
+    - DoubleConversion
+    - GLog
+  - GLog (0.3.4)
+  - native-navigation (0.2.2):
     - React
-  - React (0.42.3):
-    - React/Core (= 0.42.3)
-  - React/Core (0.42.3):
-    - React/cxxreact
-    - Yoga (= 0.42.3.React)
-  - React/cxxreact (0.42.3):
-    - React/jschelpers
-  - React/jschelpers (0.42.3)
-  - React/RCTAnimation (0.42.3):
+  - React (0.50.4):
+    - React/Core (= 0.50.4)
+  - React/Core (0.50.4):
+    - yoga (= 0.50.4.React)
+  - React/CxxBridge (0.50.4):
+    - Folly (= 2016.09.26.00)
     - React/Core
-  - React/RCTImage (0.42.3):
+    - React/cxxreact
+  - React/cxxreact (0.50.4):
+    - boost
+    - Folly (= 2016.09.26.00)
+    - React/jschelpers
+  - React/DevSupport (0.50.4):
+    - React/Core
+    - React/RCTWebSocket
+  - React/fishhook (0.50.4)
+  - React/jschelpers (0.50.4):
+    - Folly (= 2016.09.26.00)
+    - React/PrivateDatabase
+  - React/PrivateDatabase (0.50.4)
+  - React/RCTAnimation (0.50.4):
+    - React/Core
+  - React/RCTBlob (0.50.4):
+    - React/Core
+  - React/RCTImage (0.50.4):
     - React/Core
     - React/RCTNetwork
-  - React/RCTNetwork (0.42.3):
+  - React/RCTNetwork (0.50.4):
     - React/Core
-  - React/RCTText (0.42.3):
+  - React/RCTText (0.50.4):
     - React/Core
-  - React/RCTWebSocket (0.42.3):
+  - React/RCTWebSocket (0.50.4):
     - React/Core
-  - Yoga (0.42.3.React)
+    - React/fishhook
+    - React/RCTBlob
+  - yoga (0.50.4.React)
 
 DEPENDENCIES:
+  - DoubleConversion (from `../../node_modules/react-native/third-party-podspecs/DoubleConversion.podspec`)
+  - Folly (from `../../node_modules/react-native/third-party-podspecs/Folly.podspec`)
+  - GLog (from `../../node_modules/react-native/third-party-podspecs/GLog.podspec`)
   - native-navigation (from `../../`)
   - React/Core (from `../../node_modules/react-native`)
+  - React/CxxBridge (from `../../node_modules/react-native`)
+  - React/DevSupport (from `../../node_modules/react-native`)
   - React/RCTAnimation (from `../../node_modules/react-native`)
   - React/RCTImage (from `../../node_modules/react-native`)
   - React/RCTNetwork (from `../../node_modules/react-native`)
   - React/RCTText (from `../../node_modules/react-native`)
   - React/RCTWebSocket (from `../../node_modules/react-native`)
-  - Yoga (from `../../node_modules/react-native/ReactCommon/yoga/Yoga.podspec`)
+  - yoga (from `../../node_modules/react-native/ReactCommon/yoga/yoga.podspec`)
 
 EXTERNAL SOURCES:
+  DoubleConversion:
+    :podspec: ../../node_modules/react-native/third-party-podspecs/DoubleConversion.podspec
+  Folly:
+    :podspec: ../../node_modules/react-native/third-party-podspecs/Folly.podspec
+  GLog:
+    :podspec: ../../node_modules/react-native/third-party-podspecs/GLog.podspec
   native-navigation:
-    :path: "../../"
+    :path: ../../
   React:
-    :path: "../../node_modules/react-native"
-  Yoga:
-    :path: "../../node_modules/react-native/ReactCommon/yoga/Yoga.podspec"
+    :path: ../../node_modules/react-native
+  yoga:
+    :path: ../../node_modules/react-native/ReactCommon/yoga/yoga.podspec
 
 SPEC CHECKSUMS:
-  native-navigation: 23b0ef13de8bd9aaa4dbaa115e9b7055e6844987
-  React: 35e039680feacd0563677d49ba410112d2748559
-  Yoga: 86ce777665c8259b94ef8dbea76b84634237f4ea
+  boost: 30a15ffb6d9aa4646dd3caffc960753f4cb4ca4e
+  DoubleConversion: ebb6747c5b66026ad4f97b789c3ceac6f18e57a6
+  Folly: b7255b29f1d693c375d642d0f04f0592181156d9
+  GLog: 3e4e4ae9746ce6bf6e9420c7fc1e08ad59c8ba1a
+  native-navigation: 0ebd8a62e3bee892e345f6bc0ccc29a30a4e211b
+  React: 6d7efef18e0241eb832cf4c085405169a15080ed
+  yoga: b9aebf996711e50fc31f5608c10aa108a5a0c29e
 
-PODFILE CHECKSUM: 62780c26b71f717952c8247c70052484dc91c6b3
+PODFILE CHECKSUM: 2fb86f88c222dc5cebd1e277c564850e039b1ab6
 
-COCOAPODS: 1.2.0
+COCOAPODS: 1.3.1

--- a/example/ios/native-navigation.xcodeproj/project.pbxproj
+++ b/example/ios/native-navigation.xcodeproj/project.pbxproj
@@ -170,9 +170,22 @@
 			files = (
 			);
 			inputPaths = (
+				"${SRCROOT}/Pods/Target Support Files/Pods-native-navigation/Pods-native-navigation-frameworks.sh",
+				"${BUILT_PRODUCTS_DIR}/DoubleConversion/DoubleConversion.framework",
+				"${BUILT_PRODUCTS_DIR}/Folly/folly.framework",
+				"${BUILT_PRODUCTS_DIR}/GLog/glog.framework",
+				"${BUILT_PRODUCTS_DIR}/React/React.framework",
+				"${BUILT_PRODUCTS_DIR}/native-navigation/NativeNavigation.framework",
+				"${BUILT_PRODUCTS_DIR}/yoga/yoga.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/DoubleConversion.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/folly.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/glog.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/React.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/NativeNavigation.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/yoga.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -185,13 +198,16 @@
 			files = (
 			);
 			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
 			);
 			name = "[CP] Check Pods Manifest.lock";
 			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-native-navigation-checkManifestLockResult.txt",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
 		B6D02C1952665A05D8ABE50D /* [CP] Copy Pods Resources */ = {

--- a/example/ios/native-navigation/Images.xcassets/AppIcon.appiconset/Contents.json
+++ b/example/ios/native-navigation/Images.xcassets/AppIcon.appiconset/Contents.json
@@ -39,6 +39,11 @@
       "idiom" : "iphone",
       "size" : "60x60",
       "scale" : "3x"
+    },
+    {
+      "idiom" : "ios-marketing",
+      "size" : "1024x1024",
+      "scale" : "1x"
     }
   ],
   "info" : {

--- a/example/screens/NavigationBar.js
+++ b/example/screens/NavigationBar.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { Dimensions } from 'react-native';
 
 import Navigator from 'native-navigation';

--- a/lib/ios/native-navigation/Dictionary+FunctionalExtensions.swift
+++ b/lib/ios/native-navigation/Dictionary+FunctionalExtensions.swift
@@ -40,7 +40,8 @@ extension Dictionary {
     return dict
   }
 
-
+#if swift(>=3.2)
+#else
   public func mapValues<OutValue>(transform: (Value) throws -> OutValue) rethrows -> [Key: OutValue] {
     var dict = [Key: OutValue]()
     for (key, value) in self {
@@ -48,4 +49,5 @@ extension Dictionary {
     }
     return dict
   }
+#endif
 }

--- a/lib/ios/native-navigation/SharedElementGroupManager.swift
+++ b/lib/ios/native-navigation/SharedElementGroupManager.swift
@@ -46,7 +46,7 @@ final class SharedElementGroupManager: RCTViewManager {
     return SharedElementGroup()
   }
 
-  override func constantsToExport() -> [String: Any] {
+  override func constantsToExport() -> [AnyHashable: Any] {
     return [
       "VERSION": VERSION
     ]

--- a/lib/ios/native-navigation/SharedElementManager.swift
+++ b/lib/ios/native-navigation/SharedElementManager.swift
@@ -53,7 +53,7 @@ final class SharedElementManager: RCTViewManager {
     return SharedElement()
   }
 
-  override func constantsToExport() -> [String: Any] {
+  override func constantsToExport() -> [AnyHashable: Any] {
     return [
       "VERSION": VERSION
     ]

--- a/lib/ios/native-navigation/TabBarViewManager.swift
+++ b/lib/ios/native-navigation/TabBarViewManager.swift
@@ -45,7 +45,7 @@ final class TabBarViewManager: RCTViewManager {
     return TabBar()
   }
 
-  override func constantsToExport() -> [String: Any] {
+  override func constantsToExport() -> [AnyHashable: Any] {
     return [
       "VERSION": VERSION
     ]

--- a/lib/ios/native-navigation/TabViewManager.swift
+++ b/lib/ios/native-navigation/TabViewManager.swift
@@ -81,7 +81,7 @@ final class TabViewManager: RCTViewManager {
 //    return TabView(implementation: ReactNavigationCoordinator.sharedInstance.navigation)
   }
 
-  override func constantsToExport() -> [String: Any] {
+  override func constantsToExport() -> [AnyHashable: Any] {
     return [
       "VERSION": VERSION
     ]

--- a/package.json
+++ b/package.json
@@ -1,9 +1,10 @@
 {
   "name": "native-navigation",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Native Navigation for React Native",
   "main": "index.js",
   "scripts": {
+    "postinstall":"sh postinstall.sh",
     "start": "node node_modules/react-native/local-cli/cli.js start",
     "run:packager": "./node_modules/react-native/packager/packager.sh",
     "run:ios": "react-native run-ios --project-path ./example/ios",
@@ -37,8 +38,8 @@
   },
   "homepage": "https://github.com/airbnb/native-navigation#readme",
   "peerDependencies": {
-    "react": ">=15.3.1",
-    "react-native": ">=0.42"
+    "react": ">=16.0.0",
+    "react-native": ">=0.50"
   },
   "dependencies": {
     "prop-types": "^15.5.10",
@@ -58,8 +59,8 @@
     "eslint-plugin-react": "^6.1.2",
     "gitbook-cli": "^2.3.0",
     "murmur2js": "^1.0.0",
-    "react": "^15.4.1",
-    "react-native": "^0.42.3"
+    "react": "^16.1.1",
+    "react-native": "^0.50.4"
   },
   "rnpm": {
     "android": {

--- a/postinstall.sh
+++ b/postinstall.sh
@@ -1,0 +1,4 @@
+echo 'hacking...'
+sed -i '' 's/\#import <RCTAnimation\/RCTValueAnimatedNode.h>/\#import \"RCTValueAnimatedNode.h\"/' ./node_modules/react-native/Libraries/NativeAnimation/RCTNativeAnimatedNodesManager.h
+sed -i '' 's/\#import <fishhook\/fishhook.h>/\#import <React\/fishhook.h>/' ./node_modules/react-native/Libraries/WebSocket/RCTReconnectingWebSocket.m
+echo 'hacked'


### PR DESCRIPTION
- Replace BatchedBridge with CxxBridge
- Add postinstall.sh to hack for rn >= 0.50
- Add DevSupport module for iOS examples
- bump native navigation version

Btw, I compared with other react navigation solutions and I thought it is still the best option for me. I will continuous contribute this repo at mixslice/native-navigation.