### PR TITLE
[iOS] Update swift syntax to pass a compilation with Swift 3.2.

### DIFF
--- a/lib/ios/native-navigation/ReactNavigationImplementation.swift
+++ b/lib/ios/native-navigation/ReactNavigationImplementation.swift
@@ -39,7 +39,7 @@ import React
 
 // this is a convenience class to allow us to easily assign lambdas as press handlers
 class BlockBarButtonItem: UIBarButtonItem {
-  var actionHandler: ((Void) -> Void)?
+  var actionHandler: (() -> Void)?
 
   convenience init(title: String?, style: UIBarButtonItemStyle) {
     self.init(title: title, style: style, target: nil, action: #selector(barButtonItemPressed))
@@ -84,7 +84,7 @@ class BlockBarButtonItem: UIBarButtonItem {
     }
   }
 
-  func barButtonItemPressed(sender: UIBarButtonItem) {
+  @objc func barButtonItemPressed(sender: UIBarButtonItem) {
     actionHandler?()
   }
 }

--- a/lib/ios/native-navigation/ReactTabBarController.swift
+++ b/lib/ios/native-navigation/ReactTabBarController.swift
@@ -172,7 +172,6 @@ open class ReactTabBarController: UITabBarController {
   }
 }
 
-private let DELAY: Int64 = Int64(1.2 * Double(NSEC_PER_SEC))
 private var IN_PROGRESS: Bool = false
 
 extension ReactTabBarController: UITabBarControllerDelegate {

--- a/lib/ios/native-navigation/ReactViewControllerProtocol.swift
+++ b/lib/ios/native-navigation/ReactViewControllerProtocol.swift
@@ -51,7 +51,7 @@ extension ReactTabBarController: InternalReactViewControllerProtocol {
 // we will wait a maximum of 200ms for the RN view to tell us what the navigation bar should look like.
 // should normally happen much quicker than this... This is just to make sure it transitions in a reasonable
 // time frame even if the react thread takes an extra long time.
-private let DELAY: Int64 = Int64(1.2 * Double(NSEC_PER_SEC))
+public let DELAY: Int64 = Int64(1.2 * Double(NSEC_PER_SEC))
 private var IN_PROGRESS: Bool = false
 
 

--- a/lib/ios/native-navigation/UIBarButtonItem+addAction.swift
+++ b/lib/ios/native-navigation/UIBarButtonItem+addAction.swift
@@ -10,12 +10,12 @@ import Foundation
 
 
 public class ClosureWrapper : NSObject {
-  let _callback : (Void) -> Void
-  init(callback : @escaping (Void) -> Void) {
+  let _callback : () -> Void
+  init(callback : @escaping () -> Void) {
     _callback = callback
   }
 
-  public func invoke() {
+  @objc public func invoke() {
     _callback()
   }
 }
@@ -23,7 +23,7 @@ public class ClosureWrapper : NSObject {
 var AssociatedClosure: UInt8 = 0
 
 extension UIControl {
-  func nn_addAction(forControlEvents events: UIControlEvents, withCallback callback: @escaping (Void) -> Void) {
+  func nn_addAction(forControlEvents events: UIControlEvents, withCallback callback: @escaping () -> Void) {
     let wrapper = ClosureWrapper(callback: callback)
     addTarget(wrapper, action: #selector(ClosureWrapper.invoke), for: events)
     objc_setAssociatedObject(self, &AssociatedClosure, wrapper, objc_AssociationPolicy.OBJC_ASSOCIATION_RETAIN_NONATOMIC)


### PR DESCRIPTION
## Overview

This PR updates swift syntax to 3.2 and allowing a compilation with Swift 3.2/4.0.
I'm actually not sure Airbnb is already start using Swift 3.2 or up, but we eventually have to bump the version of Swift so I thought it's not a bad idea to send PR to master repo.

Give your thought if you have time, thx~! 🙇