### PR TITLE
[Android] Add missing onHostDestroy call

### DIFF
--- a/lib/android/src/main/java/com/airbnb/android/react/navigation/ReactAwareActivity.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/navigation/ReactAwareActivity.java
@@ -29,6 +29,12 @@ public abstract class ReactAwareActivity extends AppCompatActivity
   }
 
   @Override
+  protected void onDestroy() {
+    super.onDestroy();
+    reactInstanceManager.onHostDestroy(this);
+  }
+
+  @Override
   public void invokeDefaultOnBackPressed() {
     onBackPressed();
   }


### PR DESCRIPTION
Adds the `onHostDestroy` method call. Lacking this call can cause problems when using features that rely on your React lifecycle.

Besides, we're already calling `onHostPause` and `onHostResume` so, for the sake of consistency, we should also do `onHostDestroy` 😄 