### PR TITLE
[Android] Fix crash when current BackStack is null

### DIFF
--- a/lib/android/src/main/java/com/airbnb/android/react/navigation/ScreenCoordinator.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/navigation/ScreenCoordinator.java
@@ -109,6 +109,10 @@ public class ScreenCoordinator {
       ft.setCustomAnimations(anim.enter, anim.exit, anim.popEnter, anim.popExit);
     }
     BackStack bsi = getCurrentBackStack();
+    if (bsi == null) {
+      Log.w(TAG, "Trying to push with a null BackStack.");
+      return;
+    }
     ft
             .detach(currentFragment)
             .add(container.getId(), fragment)
@@ -209,6 +213,10 @@ public class ScreenCoordinator {
 
   public void pop() {
     BackStack bsi = getCurrentBackStack();
+    if (bsi == null) {
+      Log.w(TAG, "Trying to pop with a null BackStack.");
+      return;
+    }
     if (bsi.getSize() == 1) {
       dismiss();
       return;
@@ -281,7 +289,10 @@ public class ScreenCoordinator {
   }
 
   private BackStack getCurrentBackStack() {
-    return backStacks.peek();
+    if (backStacks.size() > 0) {
+      return backStacks.peek();
+    }
+    return null;
   }
 
   @NonNull


### PR DESCRIPTION
At some point, the `backStacks` object can be null, making `backStacks.peek()` crash the app. I could not put my finger exactly on why this happens, but I suspect it's some kind of race condition. Anyway, it's always when trying to `pop()`.

This PR does two things to address this problem:
1. Adds a null check before trying to peek into our `backStacks`.
2. Logs a warning every time we would try to `pop` or `push` with a null `backStacks`. That way we won't lose track of the problem.

This fixed the problem in our production app without any side effects but maybe somebody with more context on the code can clarify why this crash happens and whether this is an acceptable fix.