### PR TITLE
rightTitle - Clear menu beforehand

### DIFF
--- a/lib/android/src/main/java/com/airbnb/android/react/navigation/DefaultNavigationImplementation.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/navigation/DefaultNavigationImplementation.java
@@ -517,7 +517,8 @@ public class DefaultNavigationImplementation implements NavigationImplementation
       }
     }
     if (stringHasChanged("rightTitle", prev, next)) {
-      if (next.hasKey("rightTitle")) {
+        menu.clear();
+        if (next.hasKey("rightTitle")) {
         String rightTitle = next.getString("rightTitle");
         MenuItem item = menu.add(rightTitle);
         item.setShowAsAction(MenuItem.SHOW_AS_ACTION_IF_ROOM);


### PR DESCRIPTION
Currently all `rightTitle`s from different fragments are merged into one - unless otherwise needed, it makes more sense to have every new `rightTitle` overwrite the previous.